### PR TITLE
make things immutable to speed up dist zilla

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - make things immutable to speed up dist zilla
 
 0.103001  2014-05-20 20:45:43-04:00 America/New_York
         - load Class::Load, which older Moose does not automatically load

--- a/lib/Pod/Elemental/Document.pm
+++ b/lib/Pod/Elemental/Document.pm
@@ -111,4 +111,6 @@ sub new_from_lol {
   return $self;
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Generic/Blank.pm
+++ b/lib/Pod/Elemental/Element/Generic/Blank.pm
@@ -17,4 +17,6 @@ use namespace::autoclean;
 
 sub as_debug_string { '|' }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Generic/Command.pm
+++ b/lib/Pod/Elemental/Element/Generic/Command.pm
@@ -27,4 +27,6 @@ has command => (
 
 with 'Pod::Elemental::Command';
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Generic/Nonpod.pm
+++ b/lib/Pod/Elemental/Element/Generic/Nonpod.pm
@@ -13,4 +13,6 @@ non-pod content found in the Pod stream.
 
 =cut
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Generic/Text.pm
+++ b/lib/Pod/Elemental/Element/Generic/Text.pm
@@ -15,4 +15,6 @@ simple flat paragraphs.
 
 =cut
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Nested.pm
+++ b/lib/Pod/Elemental/Element/Nested.pm
@@ -44,4 +44,6 @@ override as_pod_string => sub {
   return $string;
 };
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Command.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Command.pm
@@ -24,4 +24,6 @@ paragraphs in a Pod5 document.
 
 use namespace::autoclean;
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Data.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Data.pm
@@ -15,4 +15,6 @@ data element contained in them.
 
 use namespace::autoclean;
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Nonpod.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Nonpod.pm
@@ -29,4 +29,6 @@ sub as_pod_string {
   return sprintf "=cut\n%s=pod\n", $self->content;
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Ordinary.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Ordinary.pm
@@ -20,4 +20,6 @@ Pod document that's gone through the Pod5 translator.
 
 use namespace::autoclean;
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Region.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Region.pm
@@ -156,5 +156,6 @@ use Pod::Elemental::Types qw(ChompedString);
 has '+content' => (coerce => 1, isa => ChompedString);
 # END   Autochomp Replacement
 
+__PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/Pod/Elemental/Element/Pod5/Verbatim.pm
+++ b/lib/Pod/Elemental/Element/Pod5/Verbatim.pm
@@ -26,4 +26,6 @@ following paragraph is a verbatim paragraph:
 
 use namespace::autoclean;
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Objectifier.pm
+++ b/lib/Pod/Elemental/Objectifier.pm
@@ -75,4 +75,6 @@ sub element_class_for_event {
   return $class_for->{ $t };
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Transformer/Gatherer.pm
+++ b/lib/Pod/Elemental/Transformer/Gatherer.pm
@@ -109,4 +109,6 @@ sub transform_node {
   return $node;
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Transformer/Nester.pm
+++ b/lib/Pod/Elemental/Transformer/Nester.pm
@@ -144,4 +144,6 @@ sub transform_node {
   return $node;
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/Pod/Elemental/Transformer/Pod5.pm
+++ b/lib/Pod/Elemental/Transformer/Pod5.pm
@@ -287,4 +287,6 @@ sub transform_node {
   return $node;
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;


### PR DESCRIPTION
I don't know if this might be useless because all the classes must be mutable for some reason i don't know yet, but when i ran dzil build on Moose with this patch installed, the results were massive.

Before: https://dl.dropboxusercontent.com/u/10190786/moose_nytprof.zip

After: https://dl.dropboxusercontent.com/u/10190786/moose_nytprof_2.zip
